### PR TITLE
Patch jdk-21.0.3 with reproducible build fix for JDK-8326685

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -122,6 +122,11 @@ AC_DEFUN([FLAGS_SETUP_DEBUG_SYMBOLS],
             # Add debug prefix map gcc system include paths, as they cause
             # non-deterministic debug paths depending on gcc path location.
             DEBUG_PREFIX_MAP_GCC_INCLUDE_PATHS
+
+            # Add debug prefix map for OUTPUTDIR to handle the scenario when
+            # it is not located within WORKSPACE_ROOT
+            outputdir_slash="${OUTPUTDIR%/}/"
+            DEBUG_PREFIX_CFLAGS="$DEBUG_PREFIX_CFLAGS -fdebug-prefix-map=${outputdir_slash}="
         ]
       )
     fi


### PR DESCRIPTION
Patch for https://bugs.openjdk.org/browse/JDK-8326685 for jdk-21.0.3
To be removed for jdk-21.0.4
From fix: https://github.com/openjdk/jdk/commit/3b90ddfefea36d9f7f08ff11cd0cb099aa32b02b

Successful build with this branch: https://ci.adoptium.net/job/build-scripts/job/jobs/job/jdk21u/job/jdk21u-linux-x64-temurin/136/
